### PR TITLE
Sync branches and tags, tests for BBCloud library, Regex filtering

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ workflows:
   version: 2
   build-deploy:
     jobs:
-      - build:
+      - build-test:
           filters:
             tags:
               only: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
               only: /.*/
       - publish-docker-image:
           requires:
-            - build
+            - build-test
           filters:
             tags:
               only: /^v\d+\.\d+\.\d+$/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,15 @@
 version: 2
 jobs:
-  build:
+  build-test:
     docker:
-      - image: ciscosso/kdk:1.17.0
-        environment:
-          LANG: en_US.UTF-8
-          PATH: "/usr/local/pyenv/plugins/pyenv-virtualenv/shims:/usr/local/pyenv/shims:/usr/local/pyenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/usr/local/go/bin:/go/bin:./bin/linux_amd64/:./vendor/bin"
-          GO111MODULE: "on"
-          GOPATH: /go
+      - image: circleci/golang:1.14
     steps:
       - checkout
       - run:
           name: Make locally
           command: make all
       - run:
-          name: Generate coverage reports
+          name: Generate test reports
           command: |
             make report
             mkdir -p /tmp/artifacts

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ bin/
 dist/
 vendor/
 
+syncDirectory/
+
 meraki-cli
 cp.out
 coverage.html

--- a/cmd/gitsink/v1/gitsink.go
+++ b/cmd/gitsink/v1/gitsink.go
@@ -157,7 +157,6 @@ func Execute() { // hello
 			// Check if repos need to by synced or migrated
 			// Makes new repo on target if there doesn't already exist one
 			repos = output.SyncCheck(repos)
-			fmt.Println(repos)
 
 			// Start syncing repos
 			gitClient := git.New(input, output, integration.Name)

--- a/common/utils/string.go
+++ b/common/utils/string.go
@@ -1,0 +1,87 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+
+	common "github.com/parinithshekar/gitsink/common"
+)
+
+// FilterRepos filters the repositories according to regex and string patters
+func FilterRepos(repos []common.Repository, include []string, exclude []string) []common.Repository {
+	var finalRepos []common.Repository
+
+	// RegEx patterns
+	var includePatterns []string
+	var excludePatterns []string
+
+	// Plain repository names
+	var includeNames []string
+	var excludeNames []string
+
+	for _, pattern := range include {
+		isRE, _ := regexp.MatchString("^/.*/$", pattern)
+		if isRE { // pattern is a regular expression -> /dock.*-pl.*/
+			barePattern := strings.TrimSuffix(strings.TrimPrefix(pattern, "/"), "/")
+			includePatterns = append(includePatterns, barePattern)
+		} else { // pattern is a plain string -> repo-name-1
+			includeNames = append(includeNames, pattern)
+		}
+	}
+
+	for _, pattern := range exclude {
+		isRE, _ := regexp.MatchString("^/.*/$", pattern)
+		if isRE {
+			barePattern := strings.TrimSuffix(strings.TrimPrefix(pattern, "/"), "/")
+			excludePatterns = append(excludePatterns, barePattern)
+		} else {
+			excludeNames = append(excludeNames, pattern)
+		}
+	}
+
+	for _, repo := range repos {
+		includePass := false
+		excludePass := true
+
+		// Check if repository should be included
+		for _, pattern := range includePatterns {
+			match, _ := regexp.MatchString(pattern, repo.Slug)
+			if match {
+				includePass = true
+				break
+			}
+		}
+		if !includePass {
+			for _, name := range includeNames {
+				if name == repo.Slug {
+					includePass = true
+					break
+				}
+			}
+		}
+
+		// Check if repository should be excluded
+		for _, pattern := range excludePatterns {
+			match, _ := regexp.MatchString(pattern, repo.Slug)
+			if match {
+				excludePass = false
+				break
+			}
+		}
+		if excludePass {
+			for _, name := range excludeNames {
+				if name == repo.Slug {
+					excludePass = false
+					break
+				}
+			}
+		}
+
+		// Append to final repos if all filters pass
+		if includePass && excludePass {
+			finalRepos = append(finalRepos, repo)
+		}
+	}
+
+	return finalRepos
+}

--- a/mocks/bbcloud/bbcloud.go
+++ b/mocks/bbcloud/bbcloud.go
@@ -1,0 +1,200 @@
+package bbcloud
+
+import (
+	"errors"
+	bitbucket "github.com/ktrysmt/go-bitbucket"
+)
+
+// Teams ...
+type Teams struct {
+	AccountID, AccessToken string
+}
+
+// Repositories ...
+type Repositories struct {
+	AccountID, AccessToken string
+}
+
+// MockAPI ...
+type MockAPI struct {
+	Teams        Teams
+	Repositories Repositories
+}
+
+// Projects ...
+func (teams *Teams) Projects(kindKey string) (interface{}, error) {
+
+	// Check access token
+	if teams.AccessToken != "token" {
+		return nil, errors.New("Wrong access token")
+	}
+
+	// Check account ID
+	if teams.AccountID != "username" {
+		return nil, errors.New("Access denied")
+	}
+
+	// Check kind key
+	if kindKey != "username" {
+		// No "TEST" project key
+		var wrongRes interface{} = map[string]interface{}{
+			"values": []interface{}{
+				map[string]interface{}{
+					"key": "JETT",
+				},
+				map[string]interface{}{
+					"key": "RAZE",
+				},
+			},
+		}
+		return wrongRes, nil
+	}
+
+	// Has "TEST" project key
+	var correctRes interface{} = map[string]interface{}{
+		"values": []interface{}{
+			map[string]interface{}{
+				"key": "ABC",
+			},
+			map[string]interface{}{
+				"key": "POKE",
+			},
+			map[string]interface{}{
+				"key": "TEST",
+			},
+		},
+	}
+	return correctRes, nil
+}
+
+// Repositories ...
+func (teams *Teams) Repositories(kindKey string) (interface{}, error) {
+
+	/* This function is only used for the authentication check.
+	Therefore, returning a dummy interface */
+
+	// Check access token
+	if teams.AccessToken != "token" {
+		return nil, errors.New("Bad credentials")
+	}
+
+	// Check account ID
+	if teams.AccountID != "username" {
+		return nil, errors.New("Access denied")
+	}
+
+	// Check kind key
+	if kindKey != "username" {
+		return nil, errors.New("Wrong kind key")
+	}
+
+	var res interface{} = "Team.Repositories"
+	return res, nil
+}
+
+// ListForAccount ...
+func (repositories *Repositories) ListForAccount(ro *bitbucket.RepositoriesOptions) (*bitbucket.RepositoriesRes, error) {
+
+	// Check access token
+	if repositories.AccessToken != "token" {
+		return nil, errors.New("Bad credentials")
+	}
+
+	// Check account ID
+	if repositories.AccountID != "username" {
+		return nil, errors.New("Access denied")
+	}
+
+	// Check kind key
+	if ro.Owner != "username" {
+		return nil, errors.New("Access Denied")
+	}
+
+	var res bitbucket.RepositoriesRes = bitbucket.RepositoriesRes{
+		Page:     1,
+		Pagelen:  3,
+		MaxDepth: 1,
+		Size:     3,
+		Items: []bitbucket.Repository{
+			{
+				Project: bitbucket.Project{
+					Key:  "WRONG",
+					Name: "Rolling Thunder",
+				},
+				Slug:        "repo-1",
+				Full_name:   "repo-1",
+				Description: "repository for testing",
+				ForkPolicy:  "fork_policy",
+				Type:        "repository",
+				Owner: map[string]interface{}{
+					"one": 1,
+				},
+				Links: map[string]interface{}{
+					"clone": []interface{}{
+						map[string]string{
+							"name": "ssh",
+							"href": "@ssh+repo1.link",
+						},
+						map[string]string{
+							"name": "https",
+							"href": "https://gitclub.com/username/repo-1.git",
+						},
+					},
+				},
+			},
+			{
+				Project: bitbucket.Project{
+					Key:  "TEST",
+					Name: "testing BB Cloud",
+				},
+				Slug:        "repo-2",
+				Full_name:   "repo-2",
+				Description: "repository for testing",
+				ForkPolicy:  "fork_policy",
+				Type:        "repository",
+				Owner: map[string]interface{}{
+					"one": 1,
+				},
+				Links: map[string]interface{}{
+					"clone": []interface{}{
+						map[string]string{
+							"name": "ssh",
+							"href": "@ssh+repo2.link",
+						},
+						map[string]string{
+							"name": "https",
+							"href": "https://gitclub.com/username/repo-2.git",
+						},
+					},
+				},
+			},
+			{
+				Project: bitbucket.Project{
+					Key:  "TEST",
+					Name: "testing BB Cloud",
+				},
+				Slug:        "repo-3",
+				Full_name:   "repo-3",
+				Description: "repository for testing",
+				ForkPolicy:  "fork_policy",
+				Type:        "repository",
+				Owner: map[string]interface{}{
+					"one": 1,
+				},
+				Links: map[string]interface{}{
+					"clone": []interface{}{
+						map[string]string{
+							"name": "ssh",
+							"href": "@ssh+repo3.link",
+						},
+						map[string]string{
+							"name": "https",
+							"href": "https://gitclub.com/username/repo-3.git",
+						},
+					},
+				},
+			},
+		},
+	}
+	return &res, nil
+}

--- a/plugins/input/bitbucket/cloud/cloud.go
+++ b/plugins/input/bitbucket/cloud/cloud.go
@@ -12,6 +12,7 @@ import (
 
 	common "github.com/parinithshekar/gitsink/common"
 	config "github.com/parinithshekar/gitsink/common/config"
+	utils "github.com/parinithshekar/gitsink/common/utils"
 	logger "github.com/parinithshekar/gitsink/wrap/logrus/v1"
 )
 
@@ -35,7 +36,11 @@ type Cloud struct {
 	accountID   string
 	accessToken string
 	kind        string
-	API         struct {
+	filters     struct {
+		include []string
+		exclude []string
+	}
+	API struct {
 		Teams        Teams
 		Repositories Repositories
 	}
@@ -98,6 +103,9 @@ func New(source config.Source) (*Cloud, error) {
 	cloud.accessToken = source.AccessToken
 
 	cloud.kind = source.Kind
+
+	cloud.filters.include = source.Repositories.Include
+	cloud.filters.exclude = source.Repositories.Exclude
 
 	cloud.setAPIClient()
 	return cloud, nil
@@ -208,6 +216,7 @@ func (cloud Cloud) Repositories(metadata bool) ([]common.Repository, error) {
 				repositories = append(repositories, newRepo)
 			}
 		}
+		repositories = utils.FilterRepos(repositories, cloud.filters.include, cloud.filters.exclude)
 		return repositories, nil
 
 	case "user":
@@ -236,6 +245,7 @@ func (cloud Cloud) Repositories(metadata bool) ([]common.Repository, error) {
 			}
 			repositories = append(repositories, newRepo)
 		}
+		repositories = utils.FilterRepos(repositories, cloud.filters.include, cloud.filters.exclude)
 		return repositories, nil
 
 	default:

--- a/plugins/input/bitbucket/cloud/cloud_test.go
+++ b/plugins/input/bitbucket/cloud/cloud_test.go
@@ -20,8 +20,8 @@ var (
 		AccessToken: envAccessToken,
 		Kind:        "user/username",
 		Repositories: config.Repositories{
-			Include: []string{".*-suffix"},
-			Exclude: []string{"prefix-.*"},
+			Include: []string{"/.*/"},
+			Exclude: []string{"/^hello$/"},
 		},
 	}
 )

--- a/plugins/input/bitbucket/server/server_test.go
+++ b/plugins/input/bitbucket/server/server_test.go
@@ -21,8 +21,8 @@ var (
 		AccessToken: envAccessToken,
 		Kind:        "user/username",
 		Repositories: config.Repositories{
-			Include: []string{".*-suffix"},
-			Exclude: []string{"prefix-.*"},
+			Include: []string{"/.*/"},
+			Exclude: []string{"/^hello$/"},
 		},
 	}
 )
@@ -254,6 +254,7 @@ func TestRepositories(t *testing.T) {
 			// Validate
 			resultOK := (actualResult == tc.ExpectedResult)
 			errorOK := (actualError == tc.ExpectedError)
+
 			if !(resultOK && errorOK) {
 				t.Error("Repositories() test failed")
 			}

--- a/plugins/input/bitbucket/server/server_test.go
+++ b/plugins/input/bitbucket/server/server_test.go
@@ -255,7 +255,7 @@ func TestRepositories(t *testing.T) {
 			resultOK := (actualResult == tc.ExpectedResult)
 			errorOK := (actualError == tc.ExpectedError)
 			if !(resultOK && errorOK) {
-				t.Error("Authentication test failed")
+				t.Error("Repositories() test failed")
 			}
 		})
 	}

--- a/plugins/output/git/git.go
+++ b/plugins/output/git/git.go
@@ -5,7 +5,10 @@ import (
 	"os"
 	"strings"
 
+	logrus "github.com/sirupsen/logrus"
 	git "github.com/go-git/go-git/v5"
+	config "github.com/go-git/go-git/v5/config"
+	http "github.com/go-git/go-git/v5/plumbing/transport/http"
 
 	common "github.com/parinithshekar/gitsink/common"
 	plugins "github.com/parinithshekar/gitsink/plugins/interfaces"
@@ -51,32 +54,45 @@ func (gitClient Client) SyncRepos(repos []common.Repository) {
 	}
 	os.Chdir(gitClient.integrationName)
 
-	// Get authenticated link for cloning repo
+	// Get authentication object for source
 	sourceAccountID, sourceAccessToken, err := gitClient.input.Credentials()
 	if err != nil {
 		log.Errorf("Failed to fetch source credentials")
 		return
+	}
+	sourceAuth := http.BasicAuth{
+		Username: sourceAccountID,
+		Password: sourceAccessToken,
 	}
 
 	for _, repo := range repos {
 
 		var localRepo *git.Repository
 		if _, err := os.Stat(repo.Slug); os.IsNotExist(err) {
-
-			sourceLinkDomain := strings.SplitN(repo.Source, "//", 2)[1]
-			authSourceLink := fmt.Sprintf("https://%v:%v@%v", sourceAccountID, sourceAccessToken, sourceLinkDomain)
-
 			// Clone the repo
-			localRepo, _ = git.PlainClone(repo.Slug, false, &git.CloneOptions{URL: authSourceLink})
+			co := git.CloneOptions{
+				URL: repo.Source,
+				Auth: &sourceAuth,
+			}
+			co.Validate()
+			localRepo, _ = git.PlainClone(repo.Slug, false, &co)
 		}
-		os.Chdir(repo.Slug)
+
+		_, err := localRepo.CreateRemote(&config.RemoteConfig{
+			Name: "target",
+			URLs: []string{repo.Target},
+		})
+		if err != nil {
+			log.WithFields(logrus.Fields{
+				"integration": gitClient.integrationName,
+				"repository": repo.Slug,
+				"error": err.Error(),
+			}).Errorf("Failed to set target remote")
+		}
 
 		// TODO: yet to handle and report errors in logs
 		gitClient.SyncTags(repo, localRepo)
 		gitClient.SyncBranches(repo, localRepo)
-
-		// back to /syncDirectory/integration-name
-		os.Chdir("..")
 	}
 
 	// back to project root
@@ -85,55 +101,210 @@ func (gitClient Client) SyncRepos(repos []common.Repository) {
 
 // SyncTags individually syncs the tags from source remote to the target remote
 func (gitClient Client) SyncTags(repo common.Repository, localRepo *git.Repository) {
-	// Sync Tags individually
 
-	// Get authenticated link for fetching
+	// Get authentication object for source
 	sourceAccountID, sourceAccessToken, err := gitClient.input.Credentials()
 	if err != nil {
-		log.Errorf("Failed to fetch source credentials")
+		log.WithFields(logrus.Fields{
+			"integration": gitClient.integrationName,
+			"repository": repo.Slug,
+			"error": err.Error(),
+		}).Errorf("Failed to fetch source credentials")
 		return
 	}
-	sourceLinkDomain := strings.SplitN(repo.Source, "//", 2)[1]
-	authSourceLink := fmt.Sprintf("https://%v:%v@%v", sourceAccountID, sourceAccessToken, sourceLinkDomain)
-	authSourceLink = string(authSourceLink)
+	sourceAuth := http.BasicAuth{
+		Username: sourceAccountID,
+		Password: sourceAccessToken,
+	}
 
-	// Get authenticated link for pushing
+	// Get authentication object for target
 	targetAccountID, targetAccessToken, err := gitClient.output.Credentials()
 	if err != nil {
-		log.Errorf("Failed to fetch target credentials")
+		log.WithFields(logrus.Fields{
+			"integration": gitClient.integrationName,
+			"repository": repo.Slug,
+			"error": err.Error(),
+		}).Errorf("Failed to fetch target credentials")
 		return
 	}
-	targetLinkDomain := strings.SplitN(repo.Target, "//", 2)[1]
-	authTargetLink := fmt.Sprintf("https://%v:%v@%v", targetAccountID, targetAccessToken, targetLinkDomain)
-	authTargetLink = string(authTargetLink)
+	targetAuth := http.BasicAuth{
+		Username: targetAccountID,
+		Password: targetAccessToken,
+	}
 
-	localRepo.Fetch(&git.FetchOptions{})
+	// Fetch from origin
+	fo := git.FetchOptions{
+		RemoteName: "origin",
+		Auth: &sourceAuth,
+	}
+	fo.Validate()
+	err = localRepo.Fetch(&fo)
 
+	remotes, _ := localRepo.Remotes()
+	for _, remote := range(remotes) {
+		fmt.Println("\n", remote.String())
+	}
+
+	if err != nil && err.Error() != "already up-to-date" {
+		log.WithFields(logrus.Fields{
+			"integration": gitClient.integrationName,
+			"repository": repo.Slug,
+			"error": err.Error(),
+		}).Warningf("Failed to get remote refs")
+	}
+
+	// Get list of origin tags
+	origin, err := localRepo.Remote("origin")
+	refs, err := origin.List(&git.ListOptions{
+		Auth: &sourceAuth,
+	})
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"integration": gitClient.integrationName,
+			"repository": repo.Slug,
+			"error": err.Error(),
+		}).Warningf("Failed to fetch tags from origin")
+	}
+
+	// Parse list of tag names
+	var tags []string
+	for _, ref := range(refs) {
+		if (ref.Name().IsTag()) {
+			tags = append(tags, strings.SplitN(ref.Name().String(), "refs/tags/", 2)[1])
+		}
+	}
+
+	// Sync tags
+	for _, tag := range(tags) {
+		
+		// Build refspec
+		tagRefspec := fmt.Sprintf("refs/tags/%v:refs/tags/%v", tag, tag)
+
+		// Push tag to target remote
+		po := git.PushOptions{
+			RemoteName: "target",
+			Auth: &targetAuth,
+			RefSpecs: []config.RefSpec{ config.RefSpec(tagRefspec) },
+		}
+		po.Validate()
+		err = localRepo.Push(&po)
+
+		// Report errors if any
+		if (err != nil) && (err.Error() != "already up-to-date") {
+			log.WithFields(logrus.Fields{
+				"integration": gitClient.integrationName,
+				"repository": repo.Slug,
+				"tag": tag,
+				"error": err.Error(),
+			}).Errorf("Tag could not be synced")
+		}
+
+	}
+}
+
+func reorderDefault(branches []string, keyBranch string) []string {
+	if len(branches) == 0 || branches[0] == keyBranch {
+        return branches
+    } 
+    if branches[len(branches)-1] == keyBranch {
+        branches = append([]string{keyBranch}, branches[:len(branches)-1]...)
+        return branches
+    } 
+    for i, branch := range branches {
+        if branch == keyBranch {
+            branches = append([]string{keyBranch}, append(branches[:i], branches[i+1:]...)...)
+            break
+        }
+    }
+    return branches
 }
 
 // SyncBranches individually syncs the branches from source remote to the target remote
 func (gitClient Client) SyncBranches(repo common.Repository, localRepo *git.Repository) {
-	// Sync Branches individually
-
-	// Get authenticated link for fetching
+	
+	// Get authentication object for source
 	sourceAccountID, sourceAccessToken, err := gitClient.input.Credentials()
-	if err != nil {
-		log.Errorf("Failed to fetch source credentials")
-		return
+	sourceAuth := http.BasicAuth{
+		Username: sourceAccountID,
+		Password: sourceAccessToken,
 	}
-	sourceLinkDomain := strings.SplitN(repo.Source, "//", 2)[1]
-	authSourceLink := fmt.Sprintf("https://%v:%v@%v", sourceAccountID, sourceAccessToken, sourceLinkDomain)
-	authSourceLink = string(authSourceLink)
 
-	// Get authenticated link for pushing
+	// Get authentication object for target
 	targetAccountID, targetAccessToken, err := gitClient.output.Credentials()
-	if err != nil {
-		log.Errorf("Failed to fetch target credentials")
-		return
+	targetAuth := http.BasicAuth{
+		Username: targetAccountID,
+		Password: targetAccessToken,
 	}
-	targetLinkDomain := strings.SplitN(repo.Target, "//", 2)[1]
-	authTargetLink := fmt.Sprintf("https://%v:%v@%v", targetAccountID, targetAccessToken, targetLinkDomain)
-	authTargetLink = string(authTargetLink)
 
-	localRepo.Fetch(&git.FetchOptions{})
+	// Fetch from origin
+	fo := git.FetchOptions{
+		RemoteName: "origin",
+		Auth: &sourceAuth,
+	}
+	fo.Validate()
+	err = localRepo.Fetch(&fo)
+	if err != nil && err.Error() != "already up-to-date" {
+		log.WithFields(logrus.Fields{
+			"integration": gitClient.integrationName,
+			"repository": repo.Slug,
+			"error": err.Error(),
+		}).Warningf("Failed to fetch tags from origin")
+	}
+
+	// Get list of origin branches
+	origin, err := localRepo.Remote("origin")
+	refs, err := origin.List(&git.ListOptions{
+		Auth: &sourceAuth,
+	})
+	if err != nil {
+		log.WithFields(logrus.Fields{
+			"integration": gitClient.integrationName,
+			"repository": repo.Slug,
+			"error": err.Error(),
+		}).Warningf("Failed to get remote refs")
+	}
+
+	// Parse list of branch names
+	var branches []string
+	for _, ref := range(refs) {
+		if (ref.Name().IsBranch()) {
+			branches = append(branches, strings.SplitN(ref.Name().String(), "refs/heads/", 2)[1])
+		}
+	}
+
+	// Reorder to push default branch from source first
+	defaultBranch := "master"
+	for _, ref := range(refs) {
+		if ref.Strings()[0] == "HEAD" {
+			defaultBranch = strings.SplitN(ref.Strings()[1], "ref: refs/heads/", 2)[1]
+			break
+		}
+	}
+	branches = reorderDefault(branches, defaultBranch)
+
+	// Sync branches
+	for _, branch := range(branches) {
+		
+		// Build refspec
+		branchRefspec := fmt.Sprintf("refs/remotes/origin/%v:refs/heads/%v", branch, branch)
+
+		// Push branch to target remote
+		po := git.PushOptions{
+			RemoteName: "target",
+			Auth: &targetAuth,
+			RefSpecs: []config.RefSpec{ config.RefSpec(branchRefspec) },
+		}
+		po.Validate()
+		err = localRepo.Push(&po)
+
+		// Report errors if any
+		if (err != nil) && (err.Error() != "already up-to-date") {
+			log.WithFields(logrus.Fields{
+				"integration": gitClient.integrationName,
+				"repository": repo.Slug,
+				"branch": branch,
+				"error": err.Error(),
+			}).Errorf("Branch could not be synced")
+		}
+	}
 }


### PR DESCRIPTION
@dcwangmit01 there turned out to be few limitations in the go-git library which didn't allow for bulk syncing of branches and tags. Using the original approach of syncing one by one.

-  Implemented branches and tags syncing, logs on error.
-  Unit tests for 3rd part bitbucket-cloud library.
-  Regex and string-based filtering support for each integration.
-  Changed the CircleCI build job to a lighter base image instead of cisco-kdk

About generating fixtures for mocking APIs through curling and storing responses, I'd have to query some BB server and some account on BB Cloud to get those responses, do I check in these responses to git? Right now, considering that I'm the only one working on this, I just keep the credentials in my local ENV and don't check in any fixtures correct?

